### PR TITLE
`AESND_AllocateVoice`(`WithArg`): Return `NULL` when all voices are being used

### DIFF
--- a/libaesnd/aesndlib.c
+++ b/libaesnd/aesndlib.c
@@ -545,8 +545,8 @@ AESNDPB* AESND_AllocateVoiceWithArg(AESNDVoiceCallbackArg cb,void *cbArg)
 
 	_CPU_ISR_Disable(level);
 	for(i=0;i<MAX_VOICES;i++) {
-		pb = &__aesndvoicepb[i];
-		if(!(pb->flags&VOICE_USED)) {
+		if(!(__aesndvoicepb[i].flags&VOICE_USED)) {
+			pb = &__aesndvoicepb[i];
 			pb->voiceno = i;
 			pb->flags = (VOICE_USED|VOICE_STOPPED);
 			pb->pds = pb->yn1 = pb->yn2 = 0;


### PR DESCRIPTION
Current behavior when all voices are being used is to return the address of the last `AESNDPB` in `__aesndvoicepb[]`, which is being used already